### PR TITLE
Make USB_Device_Stack.Start block until the device is configured

### DIFF
--- a/src/usb-device.adb
+++ b/src/usb-device.adb
@@ -369,6 +369,10 @@ package body USB.Device is
    begin
       This.UDC.Initialize; --  This should actually init
       This.UDC.Start;
+
+      while This.Dev_State /= Configured loop
+         This.Poll;
+      end loop;
    end Start;
 
    -----------


### PR DESCRIPTION
…ction completes, it may write to an endpoint buffer not yet configured with EP_Setup. This change makes USB_Device_Stack.Start call Poll until Dev_State = Configured