### PR TITLE
Make Log_Event available for runtime logging

### DIFF
--- a/src/usb-logging-device.ads
+++ b/src/usb-logging-device.ads
@@ -110,9 +110,10 @@ private
    function Img (Log : Log_Event) return String
    is ("ID: " & Log.ID'Image &
        " Kind: " & Log.Kind'Image &
-       (if Log.Kind = UDC_Evt
-       then " UDC_Event: (" & USB.HAL.Device.Img (Log.UDC_Event) & ")"
-       else ""))
+       (case Log.Kind is
+       when UDC_Evt =>
+          " UDC_Event: (" & USB.HAL.Device.Img (Log.UDC_Event) & ")",
+       when others  => ""))
        with Pure_Function;
 
 end USB.Logging.Device;

--- a/src/usb-logging-device.ads
+++ b/src/usb-logging-device.ads
@@ -33,6 +33,8 @@ with USB.HAL.Device;
 
 package USB.Logging.Device is
 
+   type Log_Event is private;
+
    procedure Log (Evt : USB.HAL.Device.UDC_Event);
 
    procedure Log_Serial_Init;
@@ -58,6 +60,8 @@ package USB.Logging.Device is
    procedure Log_MIDI_RX_Discarded;
    procedure Log_MIDI_TX_Discarded;
    procedure Log_MIDI_Write_Packet;
+
+   function Get_Log_Event_Image return String;
 
 private
 
@@ -102,5 +106,13 @@ private
             null;
       end case;
    end record;
+
+   function Img (Log : Log_Event) return String
+   is ("ID: " & Log.ID'Image &
+       " Kind: " & Log.Kind'Image &
+       (if Log.Kind = UDC_Evt
+       then " UDC_Event: (" & USB.HAL.Device.Img (Log.UDC_Event) & ")"
+       else ""))
+       with Pure_Function;
 
 end USB.Logging.Device;

--- a/src/usb-logging-device__impl.adb
+++ b/src/usb-logging-device__impl.adb
@@ -37,10 +37,10 @@ package body USB.Logging.Device is
 
    Event_Buffer : array (Event_Index) of Log_Event :=
      (others => (Kind  => None, ID => 0));
-   pragma Unreferenced (Event_Buffer);
 
-   Index : Event_Index := Event_Index'First;
-   ID    : Log_Event_ID;
+   Write_Index : Event_Index := Event_Index'First;
+   Read_Index  : Event_Index := Event_Index'First;
+   ID          : Log_Event_ID;
 
    procedure Log (Evt : Log_Event);
 
@@ -50,8 +50,8 @@ package body USB.Logging.Device is
 
    procedure Log (Evt : Log_Event) is
    begin
-      Event_Buffer (Index) := Evt;
-      Index := Index + 1;
+      Event_Buffer (Write_Index) := Evt;
+      Write_Index := Write_Index + 1;
    end Log;
 
    ---------
@@ -310,4 +310,19 @@ package body USB.Logging.Device is
       Log (Log_Event'(Kind      => MIDI_Write_Packet,
                       ID        => ID));
    end Log_MIDI_Write_Packet;
+
+   function Get_Log_Event_Image return String is
+   begin
+      if Write_Index = Read_Index then
+         return "";
+      else
+         declare
+            Log_Text : String := Img (Event_Buffer (Read_Index));
+         begin
+            Read_Index := Read_Index + 1;
+            return Log_Text;
+         end;
+      end if;
+   end Get_Log_Event_Image;
+
 end USB.Logging.Device;

--- a/src/usb-logging-device__null.adb
+++ b/src/usb-logging-device__null.adb
@@ -55,4 +55,6 @@ package body USB.Logging.Device is
    procedure Log_MIDI_TX_Discarded is null;
    procedure Log_MIDI_Write_Packet is null;
 
+   function Get_Log_Event_Image return String is ("");
+
 end USB.Logging.Device;


### PR DESCRIPTION
As part of my ongoing `usb_embedded` debugging work, I have added support for exposing `Log_Event` entries at runtime.  

Previously, these events were only accessible through the debugger, which is rather cumbersome and gives no real sense of timing. The new approach allows events to be written to any log destination (UART, USB, SWD, etc.), providing a much better understanding of the chronological flow.

### Changes

- Added a single function `Get_Log_Event_Image` that returns the next pre-formatted log event from the ring buffer as a `String`.
- Kept modifications to an absolute minimum so as not to disturb the existing logging infrastructure.
- The trade-off is that the caller cannot supply their own formatting (the message is taken as already rendered by the logging framework).

This should make debugging embedded Ada applications significantly more convenient, especially on bare-metal targets.

Happy to adjust the API or implementation if you have a preferred direction.

Best regards,  
Martin Krischik