### PR TITLE
Make internal `Put_Line` configurable

### DIFF
--- a/src/usb-device.adb
+++ b/src/usb-device.adb
@@ -40,10 +40,19 @@ with USB.Utils;
 
 package body USB.Device is
 
+   Custom_Put_Line : Put_Line_Procedure := null;
+
+   procedure Set_Custom_Put_Line (Put_Line : Put_Line_Procedure) is
+   begin
+      Custom_Put_Line := Put_Line;
+   end Set_Custom_Put_Line;
+
    procedure Put_Line (Str : String);
    procedure Put_Line (Str : String) is
    begin
-      if Verbose then
+      if Custom_Put_Line /= null then
+         Custom_Put_Line.all (Str);
+      elsif Verbose then
          Ada.Text_IO.Put_Line (Str);
       end if;
    end Put_Line;

--- a/src/usb-device.adb
+++ b/src/usb-device.adb
@@ -50,10 +50,12 @@ package body USB.Device is
    procedure Put_Line (Str : String);
    procedure Put_Line (Str : String) is
    begin
-      if Custom_Put_Line /= null then
-         Custom_Put_Line.all (Str);
-      elsif Verbose then
-         Ada.Text_IO.Put_Line (Str);
+      if Verbose then
+         if Custom_Put_Line /= null then
+            Custom_Put_Line.all (Str);
+         else
+            Ada.Text_IO.Put_Line (Str);
+         end if;
       end if;
    end Put_Line;
 

--- a/src/usb-device.ads
+++ b/src/usb-device.ads
@@ -155,6 +155,24 @@ package USB.Device is
                                 CNT  :        Packet_Size)
    is abstract;
 
+   -------------
+   -- Logging --
+   -------------
+
+   type Put_Line_Procedure is access procedure (Str : String);
+   --  Access to a logging procedure with the same signature as
+   --  @code{Ada.Text_IO.Put_Line}
+
+   procedure Set_Custom_Put_Line (Put_Line : Put_Line_Procedure);
+   --   Install a custom logging procedure
+   --
+   --  @param Put_Line  The new logging procedure to use. Pass @code{null}
+   --                   to restore the original behaviour.
+   --
+   --  This can be called at any time, even after the USB stack has been
+   --  initialised and started. The change takes effect immediately for all
+   --  subsequent debug messages.
+
 private
 
    type Control_State is (Idle,


### PR DESCRIPTION
This is a follow-up to the previous `Log_Event` runtime access improvement.

The current implementation hard-codes SWD output for log events. This change makes the underlying `Put_Line` procedure fully configurable at runtime, allowing the application to redirect output to UART, USB, or any other channel. It also makes it straightforward to insert a ring buffer in front of the actual output — particularly useful when logging from interrupt context (e.g. calling `USB_Poll` from an ISR).

### Changes

- Replaced the hard-coded SWD `Put_Line` with a configurable procedure pointer.
- Added a registration function `Set_Custom_Put_Line` to install a custom output procedure.
- Minimal impact on existing code paths; the default remains SWD for backward compatibility.

**Note**: I am aware this introduces function pointers into a performance- and certification-sensitive area, which may be controversial. I deliberately kept the change as small and isolated as possible.

I would be grateful for your thoughts on whether this direction is acceptable, or if you would prefer a different approach (e.g. a tagged type, static configuration, or something else).

Best regards,  
Martin Krischik