### PR TITLE
Make Verbose flag configurable via Alire

### DIFF
--- a/alire.toml
+++ b/alire.toml
@@ -18,3 +18,4 @@ Control_Buffer_Size = {type = "Integer", first = 256, default = 256 }
 String_Buffer_Size = {type = "Integer", first = 0, default = 256 }
 Max_Strings = {type = "Integer", first = 0, default = 10 }
 Event_Log_Buffer_Size = {type = "Integer", first = 0, default = 0 }
+Log_Verbose = {type = "Boolean", default = false }

--- a/src/usb.ads
+++ b/src/usb.ads
@@ -35,6 +35,7 @@ with HAL; use HAL;
 with Usb_Embedded_Config;
 
 private with System;
+private with Usb_Embedded_Config;
 
 package USB is
 
@@ -190,7 +191,7 @@ package USB is
 
    subtype Buffer_Len is System.Storage_Elements.Storage_Offset;
 
-   Verbose : constant Boolean := False;
+   Verbose : constant Boolean := Usb_Embedded_Config.Log_Verbose;
 
    Control_Buffer_Size : constant := Usb_Embedded_Config.Control_Buffer_Size;
    Max_Strings : constant := Usb_Embedded_Config.Max_Strings;


### PR DESCRIPTION
Following the two previous pull requests that improve runtime logging, this change makes the `Verbose` flag configurable at build time through Alire.

Previously `Verbose` was a `constant` in a `private` part of the package. The only way to enable verbose logging was to clone the repository and modify the source. This made it inconvenient for users and complicated integration into larger projects.

### Changes

- Added support for the `Log_Verbose` variable in `alire.toml`.
- The internal `Verbose` constant is now set from the Alire configuration at compile time.
- Kept the constant `private` so that dead code elimination continues to work and `Put_Line` calls are removed when verbose logging is disabled.

This gives users a clean, project-level way to enable verbose logging without touching the library source.

Best regards,  
Martin Krischik